### PR TITLE
feat: expand to 28 tools with workspaces, logs, metrics, postgres, an…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,37 @@ This MCP (Model Context Protocol) server allows AI assistants like Claude to int
 
 ## Features
 
-- List all services in your Render account
-- Get details of a specific service
-- Deploy services
-- Create new services
-- Delete services
-- Get deployment history
-- Manage environment variables
-- Manage custom domains
+This server covers everything Render's official MCP server does **plus** mutating
+operations their server intentionally omits (triggering deploys, deleting resources,
+managing custom domains, restarting, and cancelling deploys).
+
+**Services**
+- List all services and get details of a specific service
+- Create services: generic `create_service` plus typed `create_web_service`,
+  `create_static_site`, and `create_cron_job`
+- Deploy, restart, and delete services
+- Manage environment variables and custom domains
+
+**Deploys**
+- Get deployment history, get a single deploy, and cancel an in-progress deploy
+
+**Workspaces**
+- List workspaces, get workspace details, and select a default workspace so
+  create/logs/metrics tools don't need an `ownerId` each call
+
+**Observability**
+- List and filter logs (`list_logs`) and enumerate log label values
+- Fetch performance metrics (`get_metrics`): CPU, memory, HTTP requests/latency,
+  bandwidth, instance count, active connections
+
+**Datastores**
+- Postgres: list, get, create, and run **read-only** SQL queries (`query_render_postgres`)
+- Key Value (Redis): list, get, and create instances
+
+> **Note on `query_render_postgres`:** this tool connects to your database using the
+> `pg` driver and enforces read-only access (single statement, `SELECT`/`WITH`/
+> `EXPLAIN`/`SHOW` only, run inside a `READ ONLY` transaction). Run `npm install`
+> after installing the package to ensure the `pg` dependency is present.
 
 ## Installation
 
@@ -60,6 +83,45 @@ render-mcp doctor
 ```
 
 ## Using with Different AI Assistants
+
+### Using with Claude Code
+
+The quickest way is the `claude mcp add` CLI, which registers the server via `npx`
+(no global install needed):
+
+```bash
+claude mcp add render -e RENDER_API_KEY=YOUR_API_KEY -- npx -y @niyogi/render-mcp start
+```
+
+By default this adds the server to the current project. Use a scope flag to change that:
+
+- `-s user` — available across all your projects
+- `-s project` — shared with your team via a checked-in `.mcp.json`
+- `-s local` (default) — just this project, only for you
+
+Alternatively, add it manually to your MCP config (`.mcp.json` in the project root,
+or `~/.claude.json` for user scope):
+
+```json
+{
+  "mcpServers": {
+    "render": {
+      "command": "npx",
+      "args": ["-y", "@niyogi/render-mcp", "start"],
+      "env": {
+        "RENDER_API_KEY": "YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+Instead of passing the key via `env`, you can store it once with
+`npx @niyogi/render-mcp configure` (saved to `~/.render-mcp/config.json`) and omit
+the `env` block.
+
+Then verify the connection inside Claude Code with the `/mcp` command — `render`
+should appear as connected and its tools listed.
 
 ### Using with Cline
 
@@ -149,6 +211,12 @@ Here are some example prompts you can use with Claude once the MCP server is con
 - "Show me the deployment history for my service"
 - "Add an environment variable to my service"
 - "Add a custom domain to my service"
+- "List my Render workspaces and select the team one"
+- "Show me the error logs for srv-123456 from the last hour"
+- "What's the CPU and memory usage for srv-123456?"
+- "Query my Render Postgres: SELECT count(*) FROM users"
+- "Restart my service srv-123456"
+- "Create a Postgres database and a Redis instance for my app"
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@niyogi/render-mcp",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Render.com MCP server for AI assistants",
   "main": "dist/index.js",
   "type": "module",
@@ -31,11 +31,13 @@
     "axios": "^1.6.7",
     "commander": "^12.0.0",
     "dotenv": "^16.4.1",
-    "inquirer": "^9.2.13"
+    "inquirer": "^9.2.13",
+    "pg": "^8.11.3"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
     "@types/node": "^20.11.10",
+    "@types/pg": "^8.11.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,9 @@ const readFile = promisify(fs.readFile);
  * Configuration for the Render MCP server
  */
 export interface RenderConfig {
-  apiKey: string;
+  apiKey?: string;
+  /** Currently selected workspace/owner ID, used as the default for create_* tools and logs/metrics. */
+  selectedOwnerId?: string;
 }
 
 /**
@@ -55,7 +57,7 @@ export async function saveConfig(config: RenderConfig): Promise<void> {
     }
     
     await writeFile(CONFIG_FILE, JSON.stringify(config, null, 2));
-    console.log(`Configuration saved to ${CONFIG_FILE}`);
+    console.error(`Configuration saved to ${CONFIG_FILE}`);
   } catch (error) {
     console.error('Error saving config:', error);
     throw new Error(`Failed to save configuration: ${error}`);
@@ -94,7 +96,8 @@ export async function configureApiKey(apiKey?: string): Promise<void> {
       throw new Error('Invalid API key');
     }
     
-    await saveConfig({ apiKey: key });
+    const existing = (await getConfig()) || {};
+    await saveConfig({ ...existing, apiKey: key });
     console.log('API key configured successfully');
   } catch (error) {
     console.error('Error testing API key:', error);
@@ -157,6 +160,24 @@ export async function runDiagnostics(): Promise<void> {
     console.error('API connection: Failed');
     console.error(`Error: ${error}`);
   }
+}
+
+/**
+ * Get the currently selected workspace/owner ID from config.
+ * @returns The selected owner ID, or null if none has been selected
+ */
+export async function getSelectedOwnerId(): Promise<string | null> {
+  const config = await getConfig();
+  return config?.selectedOwnerId || null;
+}
+
+/**
+ * Persist the selected workspace/owner ID, preserving the rest of the config.
+ * @param ownerId Owner ID to select
+ */
+export async function setSelectedOwnerId(ownerId: string): Promise<void> {
+  const existing = (await getConfig()) || {};
+  await saveConfig({ ...existing, selectedOwnerId: ownerId });
 }
 
 /**

--- a/src/createHelpers.ts
+++ b/src/createHelpers.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure helpers for building Render create-service payloads. Kept dependency-free
+ * (no MCP SDK / inquirer imports) so they can be unit-tested in isolation.
+ */
+
+/** Recursively drop undefined values so we don't send empty keys to the API. */
+export function pruneUndefined<T extends Record<string, any>>(obj: T): T {
+  const out: Record<string, any> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v === undefined) continue;
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      const nested = pruneUndefined(v);
+      if (Object.keys(nested).length > 0) out[k] = nested;
+    } else {
+      out[k] = v;
+    }
+  }
+  return out as T;
+}
+
+/**
+ * Render's create-service API models autoDeploy as the string enum "yes"/"no",
+ * not a JSON boolean. Map through; leave undefined untouched so it's pruned.
+ */
+export function toAutoDeploy(value: boolean | undefined): 'yes' | 'no' | undefined {
+  if (value === undefined) return undefined;
+  return value ? 'yes' : 'no';
+}
+
+/**
+ * Build the runtime-appropriate envSpecificDetails block. Docker services use
+ * dockerCommand (not buildCommand/startCommand), so shape the payload per runtime.
+ */
+export function buildEnvSpecificDetails(runtime: string | undefined, buildCommand?: string, startCommand?: string) {
+  if (runtime === 'docker') {
+    // dockerfilePath/dockerContext default on Render's side when omitted.
+    return pruneUndefined({ dockerCommand: startCommand });
+  }
+  return pruneUndefined({ buildCommand, startCommand });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ const program = new Command();
 program
   .name('render-mcp')
   .description('Render.com MCP server for AI assistants')
-  .version('1.0.0');
+  .version('1.1.0');
 
 program
   .command('start')

--- a/src/renderClient.ts
+++ b/src/renderClient.ts
@@ -1,15 +1,39 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 import {
   ApiResponse,
+  CreateKeyValueRequest,
+  CreatePostgresRequest,
   CreateServiceRequest,
   CustomDomain,
   DeployRequest,
   EnvVar,
+  ListResourceParams,
+  LogQueryParams,
+  MetricsQueryParams,
+  Owner,
   PaginatedResponse,
   PaginationParams,
   RenderDeploy,
   RenderService
 } from './types/renderTypes.js';
+
+/**
+ * Maps the metric type names accepted by the get_metrics tool to their
+ * corresponding Render metrics API sub-paths (GET /v1/metrics/{path}).
+ */
+const METRIC_TYPE_PATHS: Record<string, string> = {
+  cpu_usage: 'cpu',
+  cpu_limit: 'cpu-limit',
+  cpu_target: 'cpu-target',
+  memory_usage: 'memory',
+  memory_limit: 'memory-limit',
+  memory_target: 'memory-target',
+  http_request_count: 'http-requests',
+  http_latency: 'http-latency',
+  bandwidth: 'bandwidth',
+  instance_count: 'instance-count',
+  active_connections: 'active-connections'
+};
 
 /**
  * Client for interacting with the Render API
@@ -29,7 +53,10 @@ export class RenderClient {
       headers: {
         'Authorization': `Bearer ${apiKey}`,
         'Content-Type': 'application/json'
-      }
+      },
+      // Render expects array query params as repeated keys (resource=a&resource=b),
+      // not the bracketed form axios uses by default (resource[]=a).
+      paramsSerializer: { indexes: null }
     });
 
     // Add response interceptor for error handling
@@ -135,87 +162,20 @@ export class RenderClient {
    */
   async deployService(serviceId: string, options?: DeployRequest): Promise<RenderDeploy> {
     console.error(`Deploying service ${serviceId} with options: ${JSON.stringify(options || {})}`);
-    
-    try {
-      const response = await this.client.post<any>(
-        `/services/${serviceId}/deploys`,
-        options || {}
-      );
-      
-      console.error(`Deploy API response: ${JSON.stringify(response.data)}`);
-      
-      // Check if the response has the expected structure
-      if (!response.data) {
-        console.error('Deploy API response is missing data');
-        
-        // Create a mock deployment object
-        return {
-          id: `mock-deploy-${Date.now()}`,
-          commit: {
-            id: 'unknown',
-            message: 'Deployed via MCP',
-            createdAt: new Date().toISOString()
-          },
-          status: 'build_in_progress',
-          finishedAt: null,
-          createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString()
-        } as RenderDeploy;
-      }
-      
-      // If the response has a different structure than expected, try to adapt it
-      if (!response.data.data) {
-        console.error('Deploy API response has unexpected structure');
-        
-        // Try to extract deployment info from the response
-        if (typeof response.data === 'object') {
-          return {
-            id: response.data.id || `mock-deploy-${Date.now()}`,
-            commit: response.data.commit || {
-              id: 'unknown',
-              message: 'Deployed via MCP',
-              createdAt: new Date().toISOString()
-            },
-            status: response.data.status || 'build_in_progress',
-            finishedAt: response.data.finishedAt || null,
-            createdAt: response.data.createdAt || new Date().toISOString(),
-            updatedAt: response.data.updatedAt || new Date().toISOString()
-          } as RenderDeploy;
-        }
-        
-        // If we can't extract info, return a mock deployment
-        return {
-          id: `mock-deploy-${Date.now()}`,
-          commit: {
-            id: 'unknown',
-            message: 'Deployed via MCP',
-            createdAt: new Date().toISOString()
-          },
-          status: 'build_in_progress',
-          finishedAt: null,
-          createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString()
-        } as RenderDeploy;
-      }
-      
-      return response.data.data;
-    } catch (error) {
-      console.error(`Deploy API error: ${error instanceof Error ? error.message : String(error)}`);
-      
-      // Return a mock deployment object on error
-      return {
-        id: `mock-deploy-${Date.now()}`,
-        commit: {
-          id: 'unknown',
-          message: 'Deployed via MCP (error occurred)',
-          createdAt: new Date().toISOString()
-        },
-        status: 'build_in_progress',
-        finishedAt: null,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
-      } as RenderDeploy;
+
+    const response = await this.client.post<any>(
+      `/services/${serviceId}/deploys`,
+      options || {}
+    );
+
+    // Render returns the created deploy directly; tolerate a { data: ... } wrapper.
+    // Errors are NOT swallowed — they propagate so callers report a real failure
+    // rather than a fabricated success.
+    const deploy = response.data?.data ?? response.data;
+    if (!deploy || typeof deploy !== 'object') {
+      throw new Error('Deploy request returned an unexpected response from the Render API');
     }
+    return deploy as RenderDeploy;
   }
 
   /**
@@ -288,6 +248,263 @@ export class RenderClient {
     return true;
   }
 
+  // ---------------------------------------------------------------------------
+  // Workspaces / owners
+  // ---------------------------------------------------------------------------
+
+  /**
+   * List all workspaces (owners) accessible to the API key.
+   * @param params Pagination parameters
+   * @returns Raw API response (array of { owner, cursor } entries)
+   */
+  async listOwners(params?: PaginationParams): Promise<any> {
+    const config: AxiosRequestConfig = params ? { params } : {};
+    const response = await this.client.get('/owners', config);
+    return response.data;
+  }
+
+  /**
+   * Get a single workspace (owner) by ID.
+   * @param ownerId Owner ID
+   * @returns Owner details
+   */
+  async getOwner(ownerId: string): Promise<Owner> {
+    const response = await this.client.get<Owner>(`/owners/${ownerId}`);
+    return response.data;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Deploys
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Get a single deploy by ID.
+   * @param serviceId Service ID
+   * @param deployId Deploy ID
+   * @returns Deploy details
+   */
+  async getDeploy(serviceId: string, deployId: string): Promise<RenderDeploy> {
+    const response = await this.client.get<RenderDeploy>(
+      `/services/${serviceId}/deploys/${deployId}`
+    );
+    return response.data;
+  }
+
+  /**
+   * Cancel an in-progress deploy.
+   * @param serviceId Service ID
+   * @param deployId Deploy ID
+   * @returns Raw API response
+   */
+  async cancelDeploy(serviceId: string, deployId: string): Promise<any> {
+    const response = await this.client.post(
+      `/services/${serviceId}/deploys/${deployId}/cancel`
+    );
+    return response.data;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Services (mutating extras)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Restart a running service without triggering a new build/deploy.
+   * @param serviceId Service ID
+   * @returns Success status
+   */
+  async restartService(serviceId: string): Promise<boolean> {
+    await this.client.post(`/services/${serviceId}/restart`);
+    return true;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Logs
+  // ---------------------------------------------------------------------------
+
+  /**
+   * List logs for the given workspace, filtered by resource/level/etc.
+   * @param params Log query params (ownerId required)
+   * @returns Raw logs API response ({ logs, hasMore, nextStartTime, ... })
+   */
+  async listLogs(params: LogQueryParams): Promise<any> {
+    const response = await this.client.get('/logs', { params });
+    return response.data;
+  }
+
+  /**
+   * List the available values for a given log label (e.g. "level", "type").
+   * @param label Label to enumerate values for
+   * @param ownerId Owner/workspace ID
+   * @param resource Optional resource IDs to scope the values to
+   * @returns Raw API response (array of label values)
+   */
+  async listLogLabelValues(label: string, ownerId: string, resource?: string[]): Promise<any> {
+    const response = await this.client.get('/logs/values', {
+      params: { label, ownerId, resource }
+    });
+    return response.data;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Metrics
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Fetch one or more metric series for a resource. Each requested metric type
+   * maps to a Render metrics sub-endpoint; results are merged into one object
+   * keyed by metric type. Unknown metric types are reported in the result.
+   * @param params Metrics query params
+   * @returns Object keyed by metric type with the series data (or an error string)
+   */
+  async getMetrics(params: MetricsQueryParams): Promise<Record<string, any>> {
+    const { resourceId, metricTypes, startTime, endTime, resolutionSeconds } = params;
+    const baseParams: Record<string, any> = { resource: resourceId };
+    if (startTime) baseParams.startTime = startTime;
+    if (endTime) baseParams.endTime = endTime;
+    if (resolutionSeconds) baseParams.resolutionSeconds = resolutionSeconds;
+
+    const results: Record<string, any> = {};
+    for (const metricType of metricTypes) {
+      const subPath = METRIC_TYPE_PATHS[metricType];
+      if (!subPath) {
+        results[metricType] = { error: `Unknown metric type. Valid types: ${Object.keys(METRIC_TYPE_PATHS).join(', ')}` };
+        continue;
+      }
+      try {
+        const response = await this.client.get(`/metrics/${subPath}`, { params: baseParams });
+        results[metricType] = response.data;
+      } catch (error) {
+        results[metricType] = { error: error instanceof Error ? error.message : String(error) };
+      }
+    }
+    return results;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Postgres
+  // ---------------------------------------------------------------------------
+
+  /**
+   * List Render Postgres instances.
+   * @param params Optional owner/pagination filters
+   * @returns Raw API response
+   */
+  async listPostgres(params?: ListResourceParams): Promise<any> {
+    const config: AxiosRequestConfig = params ? { params } : {};
+    const response = await this.client.get('/postgres', config);
+    return response.data;
+  }
+
+  /**
+   * Get a single Postgres instance by ID.
+   * @param postgresId Postgres instance ID
+   * @returns Postgres details
+   */
+  async getPostgres(postgresId: string): Promise<any> {
+    const response = await this.client.get(`/postgres/${postgresId}`);
+    return response.data;
+  }
+
+  /**
+   * Create a new Render Postgres instance.
+   * @param request Create request
+   * @returns Created Postgres instance
+   */
+  async createPostgres(request: CreatePostgresRequest): Promise<any> {
+    const response = await this.client.post('/postgres', request);
+    return response.data;
+  }
+
+  /**
+   * Run a READ-ONLY SQL query against a Render Postgres instance. The statement
+   * is validated to be a single read (SELECT/WITH/EXPLAIN/SHOW) and executed
+   * inside a READ ONLY transaction as a defense-in-depth guardrail.
+   * @param postgresId Postgres instance ID
+   * @param sql SQL query to run (read-only)
+   * @returns Query result rows and metadata
+   */
+  async queryPostgres(postgresId: string, sql: string): Promise<any> {
+    assertReadOnlySql(sql);
+
+    // Fetch connection details for the instance.
+    const infoResponse = await this.client.get(`/postgres/${postgresId}/connection-info`);
+    const info = infoResponse.data || {};
+    const connectionString: string | undefined =
+      info.externalConnectionString || info.internalConnectionString;
+    if (!connectionString) {
+      throw new Error('Could not obtain a connection string for this Postgres instance');
+    }
+
+    // Lazily import pg so the server still runs for users who never query.
+    // The specifier is cast to any so the build does not require pg's types to
+    // be present until the dependency is actually installed.
+    let pg: any;
+    try {
+      pg = (await import('pg' as any)).default;
+    } catch {
+      throw new Error(
+        "The 'pg' package is required for query_render_postgres. Run `npm install` to enable it."
+      );
+    }
+    // Verify the server's TLS certificate by default — the connection carries
+    // DB credentials and result data. Render's external endpoints present valid
+    // certs. Allow an explicit, deliberate opt-out for unusual setups.
+    const verifyTls = process.env.RENDER_PG_SSL_NO_VERIFY !== 'true';
+    const client = new pg.Client({
+      connectionString,
+      ssl: { rejectUnauthorized: verifyTls }
+    });
+
+    await client.connect();
+    try {
+      await client.query('BEGIN TRANSACTION READ ONLY');
+      const result = await client.query(sql);
+      await client.query('ROLLBACK');
+      return {
+        rowCount: result.rowCount,
+        fields: result.fields?.map((f: any) => f.name),
+        rows: result.rows
+      };
+    } finally {
+      await client.end();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Key Value (Redis)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * List Render Key Value (Redis) instances.
+   * @param params Optional owner/pagination filters
+   * @returns Raw API response
+   */
+  async listKeyValue(params?: ListResourceParams): Promise<any> {
+    const config: AxiosRequestConfig = params ? { params } : {};
+    const response = await this.client.get('/key-value', config);
+    return response.data;
+  }
+
+  /**
+   * Get a single Key Value instance by ID.
+   * @param keyValueId Key Value instance ID
+   * @returns Key Value details
+   */
+  async getKeyValue(keyValueId: string): Promise<any> {
+    const response = await this.client.get(`/key-value/${keyValueId}`);
+    return response.data;
+  }
+
+  /**
+   * Create a new Render Key Value (Redis) instance.
+   * @param request Create request
+   * @returns Created Key Value instance
+   */
+  async createKeyValue(request: CreateKeyValueRequest): Promise<any> {
+    const response = await this.client.post('/key-value', request);
+    return response.data;
+  }
+
   /**
    * Test the API connection
    * @returns True if connection is successful
@@ -299,5 +516,34 @@ export class RenderClient {
     } catch (error) {
       return false;
     }
+  }
+}
+
+/**
+ * Validate that a SQL string is a single, read-only statement. Throws if the
+ * query is empty, contains multiple statements, or starts with anything other
+ * than a read keyword (SELECT, WITH, EXPLAIN, SHOW, TABLE, VALUES).
+ * @param sql SQL to validate
+ */
+export function assertReadOnlySql(sql: string): void {
+  const trimmed = (sql || '').trim();
+  if (!trimmed) {
+    throw new Error('SQL query is empty');
+  }
+
+  // Strip a single trailing semicolon, then reject anything with an embedded
+  // statement separator to block stacked queries (e.g. "SELECT 1; DROP ...").
+  const withoutTrailing = trimmed.replace(/;\s*$/, '');
+  if (withoutTrailing.includes(';')) {
+    throw new Error('Only a single SQL statement is allowed for read-only queries');
+  }
+
+  const firstKeyword = withoutTrailing.split(/\s+/)[0]?.toUpperCase();
+  const allowed = ['SELECT', 'WITH', 'EXPLAIN', 'SHOW', 'TABLE', 'VALUES'];
+  if (!firstKeyword || !allowed.includes(firstKeyword)) {
+    throw new Error(
+      `Only read-only queries are permitted (must start with one of: ${allowed.join(', ')}). ` +
+      `Received a statement starting with "${firstKeyword}".`
+    );
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,17 +7,68 @@ import {
   McpError
 } from '@modelcontextprotocol/sdk/types.js';
 import { RenderClient } from './renderClient.js';
-import { getApiKey } from './config.js';
+import { getApiKey, getSelectedOwnerId, setSelectedOwnerId } from './config.js';
+import { ServiceType } from './types/renderTypes.js';
+import { buildEnvSpecificDetails, pruneUndefined, toAutoDeploy } from './createHelpers.js';
 import {
+  cancelDeploySchema,
+  createCronJobSchema,
+  createKeyValueSchema,
+  createPostgresSchema,
   createServiceSchema,
+  createStaticSiteSchema,
+  createWebServiceSchema,
   deleteServiceSchema,
   deployServiceSchema,
+  getDeploySchema,
   getDeploysSchema,
+  getKeyValueSchema,
+  getMetricsSchema,
+  getPostgresSchema,
+  getSelectedWorkspaceSchema,
   getServiceSchema,
+  getWorkspaceSchema,
+  listKeyValueSchema,
+  listLogLabelValuesSchema,
+  listLogsSchema,
+  listPostgresSchema,
   listServicesSchema,
+  listWorkspacesSchema,
   manageDomainsSchema,
-  manageEnvVarsSchema
+  manageEnvVarsSchema,
+  queryRenderPostgresSchema,
+  restartServiceSchema,
+  selectWorkspaceSchema
 } from './types/toolSchemas.js';
+
+/**
+ * Wrap a JSON-serializable value in the standard MCP text-content response.
+ */
+function jsonResult(value: unknown) {
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(value, null, 2),
+      },
+    ],
+  };
+}
+
+/**
+ * Resolve an owner/workspace ID: use the explicitly provided one, otherwise
+ * fall back to the selected workspace from config. Throws if neither exists.
+ */
+async function resolveOwnerId(provided?: string): Promise<string> {
+  const ownerId = provided || (await getSelectedOwnerId());
+  if (!ownerId) {
+    throw new Error(
+      'No ownerId provided and no workspace selected. ' +
+      'Pass ownerId or call select_workspace first (list_workspaces to see options).'
+    );
+  }
+  return ownerId;
+}
 
 /**
  * Start the MCP server
@@ -36,7 +87,7 @@ export async function startServer(): Promise<void> {
     const server = new Server(
       {
         name: 'render-mcp',
-        version: '1.0.0',
+        version: '1.1.0',
       },
       {
         capabilities: {
@@ -119,44 +170,224 @@ function setupToolHandlers(server: Server, renderClient: RenderClient): void {
         description: 'Manage custom domains for a service',
         inputSchema: manageDomainsSchema,
       },
+      // --- Workspaces / owners ---
+      {
+        name: 'list_workspaces',
+        description: 'List all workspaces (owners) accessible to your API key',
+        inputSchema: listWorkspacesSchema,
+      },
+      {
+        name: 'get_workspace',
+        description: 'Get details of a specific workspace (owner)',
+        inputSchema: getWorkspaceSchema,
+      },
+      {
+        name: 'select_workspace',
+        description: 'Select a workspace as the default owner for create/logs/metrics tools',
+        inputSchema: selectWorkspaceSchema,
+      },
+      {
+        name: 'get_selected_workspace',
+        description: 'Show the currently selected default workspace',
+        inputSchema: getSelectedWorkspaceSchema,
+      },
+      // --- Deploys ---
+      {
+        name: 'get_deploy',
+        description: 'Get details of a specific deploy by ID',
+        inputSchema: getDeploySchema,
+      },
+      {
+        name: 'cancel_deploy',
+        description: 'Cancel an in-progress deploy',
+        inputSchema: cancelDeploySchema,
+      },
+      // --- Services (extras) ---
+      {
+        name: 'restart_service',
+        description: 'Restart a running service without triggering a new build/deploy',
+        inputSchema: restartServiceSchema,
+      },
+      {
+        name: 'create_web_service',
+        description: 'Create a new web service (Node, Python, Go, Rust, Ruby, Elixir, or Docker)',
+        inputSchema: createWebServiceSchema,
+      },
+      {
+        name: 'create_static_site',
+        description: 'Create a new static site',
+        inputSchema: createStaticSiteSchema,
+      },
+      {
+        name: 'create_cron_job',
+        description: 'Create a new cron job that runs on a schedule',
+        inputSchema: createCronJobSchema,
+      },
+      // --- Logs ---
+      {
+        name: 'list_logs',
+        description: 'List and filter logs across services in a workspace',
+        inputSchema: listLogsSchema,
+      },
+      {
+        name: 'list_log_label_values',
+        description: 'List the available values for a given log label (e.g. level, type, host)',
+        inputSchema: listLogLabelValuesSchema,
+      },
+      // --- Metrics ---
+      {
+        name: 'get_metrics',
+        description: 'Get performance metrics (CPU, memory, HTTP, bandwidth, instances) for a resource',
+        inputSchema: getMetricsSchema,
+      },
+      // --- Postgres ---
+      {
+        name: 'list_postgres',
+        description: 'List Render Postgres instances',
+        inputSchema: listPostgresSchema,
+      },
+      {
+        name: 'get_postgres',
+        description: 'Get details of a Render Postgres instance',
+        inputSchema: getPostgresSchema,
+      },
+      {
+        name: 'create_postgres',
+        description: 'Create a new Render Postgres instance',
+        inputSchema: createPostgresSchema,
+      },
+      {
+        name: 'query_render_postgres',
+        description: 'Run a READ-ONLY SQL query against a Render Postgres instance',
+        inputSchema: queryRenderPostgresSchema,
+      },
+      // --- Key Value (Redis) ---
+      {
+        name: 'list_key_value',
+        description: 'List Render Key Value (Redis) instances',
+        inputSchema: listKeyValueSchema,
+      },
+      {
+        name: 'get_key_value',
+        description: 'Get details of a Render Key Value instance',
+        inputSchema: getKeyValueSchema,
+      },
+      {
+        name: 'create_key_value',
+        description: 'Create a new Render Key Value (Redis) instance',
+        inputSchema: createKeyValueSchema,
+      },
     ],
   }));
 
   // Handle tool calls
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     try {
-      if (!request.params.arguments) {
+      // Most tools require arguments; get_selected_workspace takes none.
+      if (!request.params.arguments && request.params.name !== 'get_selected_workspace') {
         throw new McpError(
           ErrorCode.InvalidParams,
           'Tool arguments are required'
         );
       }
 
+      const args = (request.params.arguments || {}) as any;
+
       switch (request.params.name) {
         case 'list_services':
-          return await handleListServices(renderClient, request.params.arguments.params);
+          return await handleListServices(renderClient, args.params);
         
         case 'get_service':
-          return await handleGetService(renderClient, request.params.arguments.params);
+          return await handleGetService(renderClient, args.params);
         
         case 'deploy_service':
-          return await handleDeployService(renderClient, request.params.arguments.params);
+          return await handleDeployService(renderClient, args.params);
         
         case 'create_service':
-          return await handleCreateService(renderClient, request.params.arguments.params);
+          return await handleCreateService(renderClient, args.params);
         
         case 'delete_service':
-          return await handleDeleteService(renderClient, request.params.arguments.params);
+          return await handleDeleteService(renderClient, args.params);
         
         case 'get_deploys':
-          return await handleGetDeploys(renderClient, request.params.arguments.params);
+          return await handleGetDeploys(renderClient, args.params);
         
         case 'manage_env_vars':
-          return await handleManageEnvVars(renderClient, request.params.arguments.params);
+          return await handleManageEnvVars(renderClient, args.params);
         
         case 'manage_domains':
-          return await handleManageDomains(renderClient, request.params.arguments.params);
-        
+          return await handleManageDomains(renderClient, args.params);
+
+        case 'list_workspaces':
+          return await handleListWorkspaces(renderClient, args.params);
+
+        case 'get_workspace':
+          return await handleGetWorkspace(renderClient, args.params);
+
+        case 'select_workspace':
+          return await handleSelectWorkspace(renderClient, args.params);
+
+        case 'get_selected_workspace':
+          return await handleGetSelectedWorkspace();
+
+        case 'get_deploy':
+          return jsonResult(await renderClient.getDeploy(
+            args.params.serviceId,
+            args.params.deployId
+          ));
+
+        case 'cancel_deploy':
+          return jsonResult(await renderClient.cancelDeploy(
+            args.params.serviceId,
+            args.params.deployId
+          ));
+
+        case 'restart_service':
+          await renderClient.restartService(args.params.serviceId);
+          return jsonResult({ message: `Service ${args.params.serviceId} restart requested` });
+
+        case 'create_web_service':
+          return await handleCreateWebService(renderClient, args.params);
+
+        case 'create_static_site':
+          return await handleCreateStaticSite(renderClient, args.params);
+
+        case 'create_cron_job':
+          return await handleCreateCronJob(renderClient, args.params);
+
+        case 'list_logs':
+          return await handleListLogs(renderClient, args.params);
+
+        case 'list_log_label_values':
+          return await handleListLogLabelValues(renderClient, args.params);
+
+        case 'get_metrics':
+          return jsonResult(await renderClient.getMetrics(args.params));
+
+        case 'list_postgres':
+          return await handleListPostgres(renderClient, args.params);
+
+        case 'get_postgres':
+          return jsonResult(await renderClient.getPostgres(args.params.postgresId));
+
+        case 'create_postgres':
+          return await handleCreatePostgres(renderClient, args.params);
+
+        case 'query_render_postgres':
+          return jsonResult(await renderClient.queryPostgres(
+            args.params.postgresId,
+            args.params.sql
+          ));
+
+        case 'list_key_value':
+          return await handleListKeyValue(renderClient, args.params);
+
+        case 'get_key_value':
+          return jsonResult(await renderClient.getKeyValue(args.params.keyValueId));
+
+        case 'create_key_value':
+          return await handleCreateKeyValue(renderClient, args.params);
+
         default:
           throw new McpError(
             ErrorCode.MethodNotFound,
@@ -299,8 +530,12 @@ async function handleDeployService(renderClient: RenderClient, params: any) {
  * Handle create_service tool
  */
 async function handleCreateService(renderClient: RenderClient, params: any) {
-  const service = await renderClient.createService(params);
-  
+  // Render models autoDeploy as "yes"/"no", not a boolean.
+  const payload = params?.autoDeploy === undefined
+    ? params
+    : { ...params, autoDeploy: toAutoDeploy(params.autoDeploy) };
+  const service = await renderClient.createService(payload);
+
   return {
     content: [
       {
@@ -416,4 +651,138 @@ async function handleManageDomains(renderClient: RenderClient, params: any) {
     default:
       throw new Error(`Unknown action: ${action}`);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Workspaces / owners
+// ---------------------------------------------------------------------------
+
+async function handleListWorkspaces(renderClient: RenderClient, params: any) {
+  const { limit, cursor } = params || {};
+  return jsonResult(await renderClient.listOwners({ limit, cursor }));
+}
+
+async function handleGetWorkspace(renderClient: RenderClient, params: any) {
+  return jsonResult(await renderClient.getOwner(params.ownerId));
+}
+
+async function handleSelectWorkspace(renderClient: RenderClient, params: any) {
+  const { ownerId } = params;
+  // Validate the workspace exists before persisting the selection.
+  const owner = await renderClient.getOwner(ownerId);
+  await setSelectedOwnerId(ownerId);
+  return jsonResult({ message: `Selected workspace ${ownerId}`, owner });
+}
+
+async function handleGetSelectedWorkspace() {
+  const ownerId = await getSelectedOwnerId();
+  return jsonResult(
+    ownerId
+      ? { selectedOwnerId: ownerId }
+      : { selectedOwnerId: null, message: 'No workspace selected. Use select_workspace.' }
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Granular service creation
+//
+// These build the nested serviceDetails payload the Render v1 create-service
+// API expects, then delegate to the generic createService client method.
+// Payload-shaping helpers live in ./createHelpers so they can be unit-tested.
+// ---------------------------------------------------------------------------
+
+async function handleCreateWebService(renderClient: RenderClient, params: any) {
+  const ownerId = await resolveOwnerId(params.ownerId);
+  const body = pruneUndefined({
+    type: ServiceType.WEB_SERVICE,
+    name: params.name,
+    ownerId,
+    repo: params.repo,
+    branch: params.branch,
+    autoDeploy: toAutoDeploy(params.autoDeploy),
+    envVars: params.envVars,
+    serviceDetails: {
+      env: params.runtime || 'node',
+      plan: params.plan,
+      region: params.region,
+      envSpecificDetails: buildEnvSpecificDetails(params.runtime, params.buildCommand, params.startCommand)
+    }
+  });
+  return jsonResult(await renderClient.createService(body as any));
+}
+
+async function handleCreateStaticSite(renderClient: RenderClient, params: any) {
+  const ownerId = await resolveOwnerId(params.ownerId);
+  const body = pruneUndefined({
+    type: ServiceType.STATIC_SITE,
+    name: params.name,
+    ownerId,
+    repo: params.repo,
+    branch: params.branch,
+    autoDeploy: toAutoDeploy(params.autoDeploy),
+    envVars: params.envVars,
+    serviceDetails: {
+      buildCommand: params.buildCommand,
+      publishPath: params.publishPath
+    }
+  });
+  return jsonResult(await renderClient.createService(body as any));
+}
+
+async function handleCreateCronJob(renderClient: RenderClient, params: any) {
+  const ownerId = await resolveOwnerId(params.ownerId);
+  const body = pruneUndefined({
+    type: ServiceType.CRON_JOB,
+    name: params.name,
+    ownerId,
+    repo: params.repo,
+    branch: params.branch,
+    envVars: params.envVars,
+    serviceDetails: {
+      env: params.runtime || 'node',
+      plan: params.plan,
+      region: params.region,
+      schedule: params.schedule,
+      envSpecificDetails: buildEnvSpecificDetails(params.runtime, params.buildCommand, params.startCommand)
+    }
+  });
+  return jsonResult(await renderClient.createService(body as any));
+}
+
+// ---------------------------------------------------------------------------
+// Logs
+// ---------------------------------------------------------------------------
+
+async function handleListLogs(renderClient: RenderClient, params: any) {
+  const ownerId = await resolveOwnerId(params?.ownerId);
+  return jsonResult(await renderClient.listLogs({ ...(params || {}), ownerId }));
+}
+
+async function handleListLogLabelValues(renderClient: RenderClient, params: any) {
+  const ownerId = await resolveOwnerId(params?.ownerId);
+  return jsonResult(await renderClient.listLogLabelValues(params.label, ownerId, params.resource));
+}
+
+// ---------------------------------------------------------------------------
+// Datastores
+// ---------------------------------------------------------------------------
+
+async function handleListPostgres(renderClient: RenderClient, params: any) {
+  const ownerId = params?.ownerId || (await getSelectedOwnerId().then(id => (id ? [id] : undefined)));
+  return jsonResult(await renderClient.listPostgres({ ...(params || {}), ownerId }));
+}
+
+async function handleCreatePostgres(renderClient: RenderClient, params: any) {
+  const ownerId = await resolveOwnerId(params.ownerId);
+  return jsonResult(await renderClient.createPostgres({ ...params, ownerId }));
+}
+
+async function handleListKeyValue(renderClient: RenderClient, params: any) {
+  const ownerId = params?.ownerId || (await getSelectedOwnerId().then(id => (id ? [id] : undefined)));
+  return jsonResult(await renderClient.listKeyValue({ ...(params || {}), ownerId }));
+}
+
+async function handleCreateKeyValue(renderClient: RenderClient, params: any) {
+  const ownerId = await resolveOwnerId(params.ownerId);
+  return jsonResult(await renderClient.createKeyValue({ ...params, ownerId }));
 }

--- a/src/types/renderTypes.ts
+++ b/src/types/renderTypes.ts
@@ -120,3 +120,80 @@ export interface PaginatedResponse<T> {
   data: T[];
   cursor?: string;
 }
+
+/**
+ * A Render workspace/owner (user or team).
+ */
+export interface Owner {
+  id: string;
+  name: string;
+  email?: string;
+  type?: string;
+}
+
+/**
+ * Filters accepted by the Render logs API (GET /v1/logs).
+ * ownerId is required; all other fields are optional filters.
+ */
+export interface LogQueryParams {
+  ownerId: string;
+  resource?: string[];
+  instance?: string[];
+  type?: string[];
+  level?: string[];
+  text?: string[];
+  host?: string[];
+  statusCode?: string[];
+  method?: string[];
+  path?: string[];
+  startTime?: string;
+  endTime?: string;
+  direction?: 'backward' | 'forward';
+  limit?: number;
+}
+
+/**
+ * Parameters for fetching metrics (GET /v1/metrics/*).
+ */
+export interface MetricsQueryParams {
+  resourceId: string;
+  metricTypes: string[];
+  startTime?: string;
+  endTime?: string;
+  resolutionSeconds?: number;
+}
+
+/**
+ * Request body for creating a Render Postgres instance (POST /v1/postgres).
+ */
+export interface CreatePostgresRequest {
+  name: string;
+  ownerId: string;
+  plan: string;
+  region?: string;
+  version?: string;
+  databaseName?: string;
+  databaseUser?: string;
+  diskSizeGB?: number;
+  highAvailabilityEnabled?: boolean;
+}
+
+/**
+ * Request body for creating a Render Key Value instance (POST /v1/key-value).
+ */
+export interface CreateKeyValueRequest {
+  name: string;
+  ownerId: string;
+  plan: string;
+  region?: string;
+  maxmemoryPolicy?: string;
+}
+
+/**
+ * Parameters for listing datastores/services scoped to owners.
+ */
+export interface ListResourceParams {
+  ownerId?: string[];
+  limit?: number;
+  cursor?: string;
+}

--- a/src/types/toolSchemas.ts
+++ b/src/types/toolSchemas.ts
@@ -247,3 +247,444 @@ export const manageDomainsSchema = {
   required: ["params"],
   additionalProperties: false
 };
+
+// ---------------------------------------------------------------------------
+// Workspaces / owners
+// ---------------------------------------------------------------------------
+
+export const listWorkspacesSchema = {
+  type: "object",
+  properties: {
+    params: {
+      type: "object",
+      properties: {
+        limit: { type: "number", description: "Number of workspaces to return (default: 20)" },
+        cursor: { type: "string", description: "Pagination cursor" }
+      },
+      additionalProperties: false
+    }
+  },
+  additionalProperties: false
+};
+
+export const getWorkspaceSchema = {
+  type: "object",
+  properties: {
+    params: {
+      type: "object",
+      properties: {
+        ownerId: { type: "string", description: "The ID of the workspace/owner to retrieve" }
+      },
+      required: ["ownerId"],
+      additionalProperties: false
+    }
+  },
+  required: ["params"],
+  additionalProperties: false
+};
+
+export const selectWorkspaceSchema = {
+  type: "object",
+  properties: {
+    params: {
+      type: "object",
+      properties: {
+        ownerId: {
+          type: "string",
+          description: "The workspace/owner ID to select as the default for subsequent tools"
+        }
+      },
+      required: ["ownerId"],
+      additionalProperties: false
+    }
+  },
+  required: ["params"],
+  additionalProperties: false
+};
+
+export const getSelectedWorkspaceSchema = {
+  type: "object",
+  properties: {},
+  additionalProperties: false
+};
+
+// ---------------------------------------------------------------------------
+// Deploys
+// ---------------------------------------------------------------------------
+
+export const getDeploySchema = {
+  type: "object",
+  properties: {
+    params: {
+      type: "object",
+      properties: {
+        serviceId: { type: "string", description: "The ID of the service" },
+        deployId: { type: "string", description: "The ID of the deploy to retrieve" }
+      },
+      required: ["serviceId", "deployId"],
+      additionalProperties: false
+    }
+  },
+  required: ["params"],
+  additionalProperties: false
+};
+
+export const cancelDeploySchema = {
+  type: "object",
+  properties: {
+    params: {
+      type: "object",
+      properties: {
+        serviceId: { type: "string", description: "The ID of the service" },
+        deployId: { type: "string", description: "The ID of the deploy to cancel" }
+      },
+      required: ["serviceId", "deployId"],
+      additionalProperties: false
+    }
+  },
+  required: ["params"],
+  additionalProperties: false
+};
+
+// ---------------------------------------------------------------------------
+// Services (mutating extras + granular creates)
+// ---------------------------------------------------------------------------
+
+export const restartServiceSchema = {
+  type: "object",
+  properties: {
+    params: {
+      type: "object",
+      properties: {
+        serviceId: { type: "string", description: "The ID of the service to restart" }
+      },
+      required: ["serviceId"],
+      additionalProperties: false
+    }
+  },
+  required: ["params"],
+  additionalProperties: false
+};
+
+const envVarsProperty = {
+  type: "array",
+  items: {
+    type: "object",
+    properties: {
+      key: { type: "string" },
+      value: { type: "string" }
+    },
+    required: ["key", "value"]
+  },
+  description: "Environment variables for the service"
+};
+
+export const createWebServiceSchema = {
+  type: "object",
+  properties: {
+    params: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Name of the web service" },
+        ownerId: { type: "string", description: "Workspace/owner ID (defaults to the selected workspace)" },
+        repo: { type: "string", description: "URL of the git repo to deploy from" },
+        branch: { type: "string", description: "Branch to deploy (default: main)" },
+        runtime: {
+          type: "string",
+          enum: ["node", "python", "go", "rust", "ruby", "elixir", "docker"],
+          description: "Runtime environment (default: node)"
+        },
+        buildCommand: { type: "string", description: "Command to build the service" },
+        startCommand: { type: "string", description: "Command to start the service" },
+        plan: { type: "string", description: "Service plan (default: starter)" },
+        region: { type: "string", description: "Region to deploy to (e.g. oregon, frankfurt)" },
+        envVars: envVarsProperty,
+        autoDeploy: { type: "boolean", description: "Auto-deploy on push (default: true)" }
+      },
+      required: ["name", "repo"],
+      additionalProperties: false
+    }
+  },
+  required: ["params"],
+  additionalProperties: false
+};
+
+export const createStaticSiteSchema = {
+  type: "object",
+  properties: {
+    params: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Name of the static site" },
+        ownerId: { type: "string", description: "Workspace/owner ID (defaults to the selected workspace)" },
+        repo: { type: "string", description: "URL of the git repo to deploy from" },
+        branch: { type: "string", description: "Branch to deploy (default: main)" },
+        buildCommand: { type: "string", description: "Command to build the site" },
+        publishPath: { type: "string", description: "Directory to publish (e.g. ./dist)" },
+        envVars: envVarsProperty,
+        autoDeploy: { type: "boolean", description: "Auto-deploy on push (default: true)" }
+      },
+      required: ["name", "repo"],
+      additionalProperties: false
+    }
+  },
+  required: ["params"],
+  additionalProperties: false
+};
+
+export const createCronJobSchema = {
+  type: "object",
+  properties: {
+    params: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Name of the cron job" },
+        ownerId: { type: "string", description: "Workspace/owner ID (defaults to the selected workspace)" },
+        repo: { type: "string", description: "URL of the git repo to deploy from" },
+        branch: { type: "string", description: "Branch to deploy (default: main)" },
+        runtime: {
+          type: "string",
+          enum: ["node", "python", "go", "rust", "ruby", "elixir", "docker"],
+          description: "Runtime environment (default: node)"
+        },
+        schedule: { type: "string", description: "Cron schedule expression (e.g. '0 * * * *')" },
+        buildCommand: { type: "string", description: "Command to build the job" },
+        startCommand: { type: "string", description: "Command the cron job runs" },
+        plan: { type: "string", description: "Service plan (default: starter)" },
+        region: { type: "string", description: "Region to deploy to" },
+        envVars: envVarsProperty
+      },
+      required: ["name", "repo", "schedule", "startCommand"],
+      additionalProperties: false
+    }
+  },
+  required: ["params"],
+  additionalProperties: false
+};
+
+// ---------------------------------------------------------------------------
+// Logs
+// ---------------------------------------------------------------------------
+
+const stringArray = (description: string) => ({
+  type: "array",
+  items: { type: "string" },
+  description
+});
+
+export const listLogsSchema = {
+  type: "object",
+  properties: {
+    params: {
+      type: "object",
+      properties: {
+        ownerId: { type: "string", description: "Workspace/owner ID (defaults to the selected workspace)" },
+        resource: stringArray("Resource IDs (e.g. service IDs) to fetch logs for"),
+        level: stringArray("Log levels to filter by (e.g. info, warning, error)"),
+        type: stringArray("Log types to filter by (e.g. app, request, build)"),
+        instance: stringArray("Instance IDs to filter by"),
+        text: stringArray("Substrings that must appear in the log text"),
+        host: stringArray("Request host filter (request logs)"),
+        statusCode: stringArray("HTTP status code filter (request logs)"),
+        method: stringArray("HTTP method filter (request logs)"),
+        path: stringArray("Request path filter (request logs)"),
+        startTime: { type: "string", description: "ISO8601 start time" },
+        endTime: { type: "string", description: "ISO8601 end time" },
+        direction: { type: "string", enum: ["backward", "forward"], description: "Search direction (default: backward)" },
+        limit: { type: "number", description: "Max number of log lines (default: 20, max: 100)" }
+      },
+      additionalProperties: false
+    }
+  },
+  additionalProperties: false
+};
+
+export const listLogLabelValuesSchema = {
+  type: "object",
+  properties: {
+    params: {
+      type: "object",
+      properties: {
+        label: { type: "string", description: "The log label to enumerate values for (e.g. 'level', 'type', 'host')" },
+        ownerId: { type: "string", description: "Workspace/owner ID (defaults to the selected workspace)" },
+        resource: stringArray("Optional resource IDs to scope the values to")
+      },
+      required: ["label"],
+      additionalProperties: false
+    }
+  },
+  required: ["params"],
+  additionalProperties: false
+};
+
+// ---------------------------------------------------------------------------
+// Metrics
+// ---------------------------------------------------------------------------
+
+export const getMetricsSchema = {
+  type: "object",
+  properties: {
+    params: {
+      type: "object",
+      properties: {
+        resourceId: { type: "string", description: "The resource ID (service, Postgres, or key-value) to fetch metrics for" },
+        metricTypes: {
+          type: "array",
+          items: {
+            type: "string",
+            enum: [
+              "cpu_usage", "cpu_limit", "cpu_target",
+              "memory_usage", "memory_limit", "memory_target",
+              "http_request_count", "http_latency", "bandwidth",
+              "instance_count", "active_connections"
+            ]
+          },
+          description: "Which metrics to fetch"
+        },
+        startTime: { type: "string", description: "ISO8601 start time" },
+        endTime: { type: "string", description: "ISO8601 end time" },
+        resolutionSeconds: { type: "number", description: "Data point resolution in seconds" }
+      },
+      required: ["resourceId", "metricTypes"],
+      additionalProperties: false
+    }
+  },
+  required: ["params"],
+  additionalProperties: false
+};
+
+// ---------------------------------------------------------------------------
+// Postgres
+// ---------------------------------------------------------------------------
+
+export const listPostgresSchema = {
+  type: "object",
+  properties: {
+    params: {
+      type: "object",
+      properties: {
+        ownerId: stringArray("Workspace/owner IDs to filter by (defaults to the selected workspace)"),
+        limit: { type: "number", description: "Number of instances to return" },
+        cursor: { type: "string", description: "Pagination cursor" }
+      },
+      additionalProperties: false
+    }
+  },
+  additionalProperties: false
+};
+
+export const getPostgresSchema = {
+  type: "object",
+  properties: {
+    params: {
+      type: "object",
+      properties: {
+        postgresId: { type: "string", description: "The ID of the Postgres instance" }
+      },
+      required: ["postgresId"],
+      additionalProperties: false
+    }
+  },
+  required: ["params"],
+  additionalProperties: false
+};
+
+export const createPostgresSchema = {
+  type: "object",
+  properties: {
+    params: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Name of the Postgres instance" },
+        ownerId: { type: "string", description: "Workspace/owner ID (defaults to the selected workspace)" },
+        plan: { type: "string", description: "Postgres plan (e.g. free, basic_256mb, pro)" },
+        region: { type: "string", description: "Region (e.g. oregon, frankfurt)" },
+        version: { type: "string", description: "Postgres major version (e.g. '16')" },
+        databaseName: { type: "string", description: "Initial database name" },
+        databaseUser: { type: "string", description: "Initial database user" },
+        diskSizeGB: { type: "number", description: "Disk size in GB" },
+        highAvailabilityEnabled: { type: "boolean", description: "Enable high availability" }
+      },
+      required: ["name", "plan"],
+      additionalProperties: false
+    }
+  },
+  required: ["params"],
+  additionalProperties: false
+};
+
+export const queryRenderPostgresSchema = {
+  type: "object",
+  properties: {
+    params: {
+      type: "object",
+      properties: {
+        postgresId: { type: "string", description: "The ID of the Postgres instance to query" },
+        sql: {
+          type: "string",
+          description: "A single READ-ONLY SQL statement (SELECT/WITH/EXPLAIN/SHOW). Writes are rejected."
+        }
+      },
+      required: ["postgresId", "sql"],
+      additionalProperties: false
+    }
+  },
+  required: ["params"],
+  additionalProperties: false
+};
+
+// ---------------------------------------------------------------------------
+// Key Value (Redis)
+// ---------------------------------------------------------------------------
+
+export const listKeyValueSchema = {
+  type: "object",
+  properties: {
+    params: {
+      type: "object",
+      properties: {
+        ownerId: stringArray("Workspace/owner IDs to filter by (defaults to the selected workspace)"),
+        limit: { type: "number", description: "Number of instances to return" },
+        cursor: { type: "string", description: "Pagination cursor" }
+      },
+      additionalProperties: false
+    }
+  },
+  additionalProperties: false
+};
+
+export const getKeyValueSchema = {
+  type: "object",
+  properties: {
+    params: {
+      type: "object",
+      properties: {
+        keyValueId: { type: "string", description: "The ID of the Key Value instance" }
+      },
+      required: ["keyValueId"],
+      additionalProperties: false
+    }
+  },
+  required: ["params"],
+  additionalProperties: false
+};
+
+export const createKeyValueSchema = {
+  type: "object",
+  properties: {
+    params: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Name of the Key Value instance" },
+        ownerId: { type: "string", description: "Workspace/owner ID (defaults to the selected workspace)" },
+        plan: { type: "string", description: "Key Value plan (e.g. free, starter, standard)" },
+        region: { type: "string", description: "Region (e.g. oregon, frankfurt)" },
+        maxmemoryPolicy: { type: "string", description: "Eviction policy (e.g. allkeys_lru, noeviction)" }
+      },
+      required: ["name", "plan"],
+      additionalProperties: false
+    }
+  },
+  required: ["params"],
+  additionalProperties: false
+};

--- a/tests/renderClient.test.ts
+++ b/tests/renderClient.test.ts
@@ -1,4 +1,4 @@
-import { RenderClient } from '../src/renderClient';
+import { RenderClient, assertReadOnlySql } from '../src/renderClient';
 import axios from 'axios';
 
 // Mock axios
@@ -114,9 +114,155 @@ describe('RenderClient', () => {
       mockAxiosInstance.get.mockRejectedValue(new Error('Connection failed'));
 
       const result = await client.testConnection();
-      
+
       expect(mockAxiosInstance.get).toHaveBeenCalled();
       expect(result).toBe(false);
     });
+  });
+
+  describe('listOwners', () => {
+    it('should list workspaces', async () => {
+      const owners = [{ owner: { id: 'tea-1', name: 'My Team' } }];
+      mockAxiosInstance.get.mockResolvedValue({ data: owners });
+
+      const result = await client.listOwners({ limit: 5 });
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/owners', { params: { limit: 5 } });
+      expect(result).toEqual(owners);
+    });
+  });
+
+  describe('getDeploy', () => {
+    it('should fetch a single deploy by id', async () => {
+      const deploy = { id: 'dep-9', status: 'live' };
+      mockAxiosInstance.get.mockResolvedValue({ data: deploy });
+
+      const result = await client.getDeploy('srv-1', 'dep-9');
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/services/srv-1/deploys/dep-9');
+      expect(result).toEqual(deploy);
+    });
+  });
+
+  describe('cancelDeploy', () => {
+    it('should POST to the cancel endpoint', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: { id: 'dep-9', status: 'canceled' } });
+
+      await client.cancelDeploy('srv-1', 'dep-9');
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/services/srv-1/deploys/dep-9/cancel');
+    });
+  });
+
+  describe('restartService', () => {
+    it('should POST to the restart endpoint', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: {} });
+
+      const result = await client.restartService('srv-1');
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/services/srv-1/restart');
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('listLogs', () => {
+    it('should pass filters through as query params', async () => {
+      mockAxiosInstance.get.mockResolvedValue({ data: { logs: [] } });
+
+      await client.listLogs({ ownerId: 'tea-1', resource: ['srv-1'], level: ['error'], limit: 10 });
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/logs', {
+        params: { ownerId: 'tea-1', resource: ['srv-1'], level: ['error'], limit: 10 }
+      });
+    });
+  });
+
+  describe('getMetrics', () => {
+    it('should fetch each metric type from its sub-endpoint', async () => {
+      mockAxiosInstance.get.mockResolvedValue({ data: [{ time: 't', value: 1 }] });
+
+      const result = await client.getMetrics({
+        resourceId: 'srv-1',
+        metricTypes: ['cpu_usage', 'memory_usage']
+      });
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/metrics/cpu', { params: { resource: 'srv-1' } });
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/metrics/memory', { params: { resource: 'srv-1' } });
+      expect(Object.keys(result)).toEqual(['cpu_usage', 'memory_usage']);
+    });
+
+    it('should report unknown metric types without calling the API', async () => {
+      const result = await client.getMetrics({ resourceId: 'srv-1', metricTypes: ['bogus'] });
+
+      expect(mockAxiosInstance.get).not.toHaveBeenCalled();
+      expect(result.bogus.error).toContain('Unknown metric type');
+    });
+  });
+
+  describe('listPostgres / listKeyValue', () => {
+    it('should list postgres instances', async () => {
+      mockAxiosInstance.get.mockResolvedValue({ data: [] });
+      await client.listPostgres({ ownerId: ['tea-1'] });
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/postgres', { params: { ownerId: ['tea-1'] } });
+    });
+
+    it('should list key-value instances', async () => {
+      mockAxiosInstance.get.mockResolvedValue({ data: [] });
+      await client.listKeyValue({ ownerId: ['tea-1'] });
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/key-value', { params: { ownerId: ['tea-1'] } });
+    });
+  });
+
+  describe('queryPostgres read-only guard', () => {
+    it('should reject a write statement before touching the API', async () => {
+      await expect(client.queryPostgres('pg-1', 'DELETE FROM users')).rejects.toThrow(/read-only/i);
+      expect(mockAxiosInstance.get).not.toHaveBeenCalled();
+    });
+
+    it('should reject stacked statements', async () => {
+      await expect(
+        client.queryPostgres('pg-1', 'SELECT 1; DROP TABLE users')
+      ).rejects.toThrow(/single SQL statement/i);
+    });
+  });
+});
+
+describe('create-service payload helpers', () => {
+  const { toAutoDeploy, buildEnvSpecificDetails } = require('../src/createHelpers');
+
+  it('maps autoDeploy boolean to Render\'s yes/no enum', () => {
+    expect(toAutoDeploy(true)).toBe('yes');
+    expect(toAutoDeploy(false)).toBe('no');
+    expect(toAutoDeploy(undefined)).toBeUndefined();
+  });
+
+  it('uses buildCommand/startCommand for native runtimes', () => {
+    expect(buildEnvSpecificDetails('node', 'npm run build', 'npm start')).toEqual({
+      buildCommand: 'npm run build',
+      startCommand: 'npm start'
+    });
+  });
+
+  it('uses dockerCommand (not build/start) for the docker runtime', () => {
+    expect(buildEnvSpecificDetails('docker', 'ignored', 'node server.js')).toEqual({
+      dockerCommand: 'node server.js'
+    });
+  });
+});
+
+describe('assertReadOnlySql', () => {
+  it('allows SELECT / WITH / EXPLAIN / SHOW', () => {
+    expect(() => assertReadOnlySql('SELECT * FROM users')).not.toThrow();
+    expect(() => assertReadOnlySql('  with x as (select 1) select * from x  ')).not.toThrow();
+    expect(() => assertReadOnlySql('EXPLAIN SELECT 1')).not.toThrow();
+    expect(() => assertReadOnlySql('SELECT 1;')).not.toThrow();
+  });
+
+  it('rejects writes, empty input, and stacked statements', () => {
+    expect(() => assertReadOnlySql('')).toThrow(/empty/i);
+    expect(() => assertReadOnlySql('DELETE FROM users')).toThrow(/read-only/i);
+    expect(() => assertReadOnlySql('UPDATE users SET x = 1')).toThrow(/read-only/i);
+    expect(() => assertReadOnlySql('DROP TABLE users')).toThrow(/read-only/i);
+    expect(() => assertReadOnlySql('SELECT 1; DELETE FROM users')).toThrow(/single SQL statement/i);
   });
 });


### PR DESCRIPTION
…d key-value

Brings parity with Render's official MCP server while retaining and extending our mutating edge (deploy, delete, restart, cancel, custom domains) which their server deliberately omits.

New tools (20):
- Workspaces: list_workspaces, get_workspace, select_workspace, get_selected_workspace (selected owner persisted in config as default for create/logs/metrics calls)
- Deploys: get_deploy, cancel_deploy
- Services: create_web_service, create_static_site, create_cron_job, restart_service (generic create_service retained for private_service / background_worker)
- Logs: list_logs, list_log_label_values
- Metrics: get_metrics (cpu, memory, http, bandwidth, instances, connections)
- Postgres: list_postgres, get_postgres, create_postgres, query_render_postgres (read-only)
- Key-Value: list_key_value, get_key_value, create_key_value

Security / correctness fixes (from adversarial review):
- query_render_postgres now verifies TLS certs by default (rejectUnauthorized: true)
- deployService no longer swallows errors and returns fabricated mock-deploy-* objects
- autoDeploy boolean mapped to Render's "yes"/"no" enum across all create paths
- Docker runtime uses dockerCommand instead of buildCommand/startCommand

Other:
- Extracted payload helpers to src/createHelpers.ts (dependency-free, unit-tested)
- Added Claude Code install section to README
- pg added as a runtime dependency (lazy import; only required for query_render_postgres)
- 21 unit tests (up from 7)